### PR TITLE
(feature): Add support for changing output format

### DIFF
--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -1,0 +1,18 @@
+package printers
+
+import (
+	"encoding/json"
+
+	"github.com/everettraven/synkr/pkg/engine"
+)
+
+type JSON struct{}
+
+func (j *JSON) Print(result engine.SourceResult) (string, error) {
+	outBytes, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+
+	return string(outBytes), nil
+}

--- a/pkg/printers/markdown.go
+++ b/pkg/printers/markdown.go
@@ -1,0 +1,48 @@
+package printers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/everettraven/synkr/pkg/engine"
+	"github.com/everettraven/synkr/pkg/sources/github"
+)
+
+type Markdown struct{}
+
+func (md *Markdown) Print(result engine.SourceResult) (string, error) {
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("# %s - %s\n", result.Source, result.Project))
+
+	for _, item := range result.Items {
+		switch item := item.(type) {
+		case github.RepoItem:
+			out.WriteString(md.PrintGitHubRepoItem(item))
+		default:
+			out.WriteString(fmt.Sprintf("%v", item))
+		}
+
+		out.WriteString("\n")
+	}
+
+	return out.String(), nil
+}
+
+func (md *Markdown) PrintGitHubRepoItem(item github.RepoItem) string {
+	var out strings.Builder
+
+	out.WriteString(fmt.Sprintf("## [%s][%s]: %s \n", item.Type, item.State, item.Title))
+	out.WriteString(fmt.Sprintf("**URL**: %s\n", item.URL))
+	out.WriteString(fmt.Sprintf("**Author**: *%s*\n", item.Author))
+	out.WriteString(fmt.Sprintf("**Assignees**: %s\n", strings.Join(item.Assignees, ",")))
+
+	out.WriteString("\n")
+	labelStrs := []string{}
+	for _, label := range item.Labels {
+		labelStrs = append(labelStrs, fmt.Sprintf("`%s`", label))
+	}
+	out.WriteString(fmt.Sprintf("%s\n\n", strings.Join(labelStrs, " ")))
+	out.WriteString(fmt.Sprintf("%s\n", item.Body))
+
+	return out.String()
+}


### PR DESCRIPTION
Adds support for changing the output format using a flag (`--output`/`-o`).

Supports Markdown and JSON outputs.

Example of the Markdown output:
```md
# GitHub - kubernetes-sigs/kube-api-linter
## [Issue][open]: Feature: Allow configuration of custom enum markers for `maxlength` linter
**URL**: https://github.com/kubernetes-sigs/kube-api-linter/issues/95
**Author**: *everettraven*
**Assignees**:



In OpenShift, we have some custom markers that set enum values for a field and this results in the `maxlength` linter stating that a field/type alias should have a maximum length when using this custom marker instead of the standard `kubebuilder:validation:Enum` marker.

While this particular case is OpenShift-specific, I think it is reasonable to make a generic way to extend this detection logic as there may be other vendors and/or projects that use their own custom markers for CRD generation.

## [PullRequest][open]: markers: fix a bug when parsing expressions with commas present in value
**URL**: https://github.com/kubernetes-sigs/kube-api-linter/pull/103
**Author**: *everettraven*
**Assignees**:

`cncf-cla: yes` `size/M`

Fixes #99

Instead of splitting on solely the `,` character, we now do some more robust normalization for parsing of markers to handle the scenarios where a marker may specify an expression with attributes the have a `,` in their value.
```

Piping the output to something like https://github.com/charmbracelet/glow makes for a great styled output in the terminal.