### PR TITLE
(feature): default to $HOME/.config/synkr.star for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ go install github.com/everettraven/synkr@latest
 
 `synkr` acts as an engine that processes configurations specified in a Starlark configuration file.
 
-By default, `synkr` will read a `synkr.star` file in the current directory. You can change the file it uses with the `--config` (alias `-c`) flag.
+By default, `synkr` will read configuration from `$HOME/.config/synkr.star`. If `synkr` is unable to determine your home directory, it will fallback to `synkr.star` in the current directory.
+
+You can change the file it uses with the `--config` (alias `-c`) flag.
 
 `synkr` has a builtin for configuring individual GitHub sources like so:
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/everettraven/synkr/pkg/builtins"
 	"github.com/everettraven/synkr/pkg/engine"
@@ -26,7 +28,7 @@ func NewSynkrCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&configFile, "config", "c", "synkr.star", "configures the Starlark file to be processed for configuration")
+	cmd.Flags().StringVarP(&configFile, "config", "c", defaultConfigPath(), "configures the Starlark file to be processed for configuration. Defaults to $HOME/.config/synkr.star if possible to get your home directory. Otherwise it uses synkr.star in the current directory.")
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "markdown", "configures the output format. Allowed values are [markdown, json]")
 
 	return cmd
@@ -60,4 +62,16 @@ func configureEngine(eng *engine.Engine, configFile, output string) (*starlark.T
 	_, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, configFile, nil, globals)
 
 	return thread, err
+}
+
+// defaultConfigPath returns the default configuration file path that should be used.
+// If we can get the users home directory we default to $HOME/.config/synkr.star, otherwise
+// we default to synkr.star
+func defaultConfigPath() string {
+    homeDir, err := os.UserHomeDir()
+    if err != nil {
+        return "synkr.star"
+    }
+
+    return filepath.Join(homeDir, ".config", "synkr.star")
 }


### PR DESCRIPTION
fixes #2 

I decided against creating the default config file if it doesn't exist. I'd rather let users create the file themselves so that I'm not writing to their $HOME directory without a user's permission.