### PR TITLE
(feature): github: add support for specifying priority of items

### DIFF
--- a/examples/multisource.star
+++ b/examples/multisource.star
@@ -1,8 +1,19 @@
-def authored_by_me(item):
+# Example of filtering out items where the author
+# is _not_ 'everettraven'
+def authored_by_not_me(item):
   author = item.get("author")
   if author != "everettraven":
-    return False
-  return True
+    return True
+  return False
 
-github(org="kubernetes-sigs", repo="kube-api-linter", filters=[authored_by_me])
-github(org="kubernetes-sigs", repo="crdify", filters=[authored_by_me])
+# Example of increasing priority score by
+# a value of '50' if the item contains the
+# label 'help wanted'
+def priority_help_wanted(item):
+  labels = item.get("labels")
+  if "help wanted" in labels:
+    return 50
+  return 0
+
+github(org="kubernetes-sigs", repo="kube-api-linter", filters=[authored_by_not_me], priorities=[priority_help_wanted])
+github(org="kubernetes-sigs", repo="crdify", filters=[authored_by_not_me])

--- a/pkg/builtins/github.go
+++ b/pkg/builtins/github.go
@@ -13,27 +13,42 @@ func Github(global starlark.StringDict, eng *engine.Engine) {
 func githubBuiltinFunc(eng *engine.Engine) BuiltinFunc {
 	return func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var filters *starlark.List
+		var priorities *starlark.List
 		var org starlark.String
 		var repo starlark.String
 
-		err := starlark.UnpackArgs("github", args, kwargs, "org", &org, "repo", &repo, "filters?", &filters)
+		err := starlark.UnpackArgs("github", args, kwargs, "org", &org, "repo", &repo, "filters?", &filters, "priorities?", &priorities)
 		if err != nil {
 			return nil, err
 		}
 
-		callables := []starlark.Callable{}
-
+		filterCallables := []starlark.Callable{}
 		if filters != nil {
-			for v := range filters.Elements() {
-				if callable, ok := v.(starlark.Callable); ok {
-					callables = append(callables, callable)
-				}
-			}
+			filterCallables = callablesFromList(filters)
 		}
 
-		ghSource := github.New(org.GoString(), repo.GoString(), callables...)
+		priorityCallables := []starlark.Callable{}
+		if priorities != nil {
+			priorityCallables = callablesFromList(priorities)
+		}
+
+		ghSource := github.New(org.GoString(), repo.GoString(), filterCallables, priorityCallables)
 		eng.AddSource(ghSource)
 
 		return starlark.None, nil
 	}
+}
+
+func callablesFromList(list *starlark.List) []starlark.Callable {
+	callables := []starlark.Callable{}
+
+	if list != nil {
+		for v := range list.Elements() {
+			if callable, ok := v.(starlark.Callable); ok {
+				callables = append(callables, callable)
+			}
+		}
+	}
+
+	return callables
 }

--- a/pkg/sources/github/types.go
+++ b/pkg/sources/github/types.go
@@ -19,4 +19,5 @@ type RepoItem struct {
 	Title     string       `json:"title"`
 	Body      string       `json:"body"`
 	State     string       `json:"state"`
+	Priority  int          `json:"priority"`
 }

--- a/pkg/sources/github/utils.go
+++ b/pkg/sources/github/utils.go
@@ -12,8 +12,6 @@ func repoItemToStarlarkDict(item RepoItem) *starlark.Dict {
 	dict := &starlark.Dict{}
 
 	// TODO: handle errors when setting keys
-	_ = dict.SetKey(starlark.String("id"), starlark.MakeInt64(item.ID))
-	_ = dict.SetKey(starlark.String("url"), starlark.String(item.URL))
 	_ = dict.SetKey(starlark.String("author"), starlark.String(item.Author))
 	_ = dict.SetKey(starlark.String("type"), starlark.String(item.Type))
 	_ = dict.SetKey(starlark.String("title"), starlark.String(item.Title))


### PR DESCRIPTION
Using the changes in this PR, users can now update the priority score of GitHub-sourced work items using a new `priorities` parameter in the `github()` builtin.

This allows for use of `synkr` in more robust pipelines where users may want to order the view of their work items based on a set of priority rules that they have defined.

While I was at it, I removed a couple values (`id` and `url`) from being included in the dictionary passed to the `filters` and `priorities` functions that are likely not all that useful for anticipated initial use cases.