### PR TITLE
(feature): github: add support for user-defined item status

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Instead of splitting on solely the `,` character, we now do some more robust nor
 In order to use the GitHub source, you use the `github` builtin function like so:
 
 ```starlark
-github(org="org", repo="repo", filters?=[...], priorities?=[...])
+github(org="org", repo="repo", filters?=[...], priorities?=[...], status?={function})
 ```
 
 `org` is the GitHub organization/user that the repository belongs to. Required.
@@ -157,6 +157,10 @@ The parameter passed to the functions is a dictionary with the following keys an
 
 `priorities` is an optional list of functions that should be called by `synkr` when determining the priority score to assign to an issue or pull request.
 The functions are expected to accept a single parameter (the same parameter as `filters` functions) and return an integer value to add to the item's priority score.
+
+`status` is an optional function that should be called by `synkr` when determining the "status" to assign to an issue or pull request.
+"status" is a distinctly different value than `state`, as it represents an arbitrary status defined by you the user instead of GitHub's perceived state of the item.
+The function is expected to accept a single parameter (the same parameter as above) and return a string value to set the item's status to.
 
 ##### Authentication
 

--- a/examples/multisource.star
+++ b/examples/multisource.star
@@ -15,5 +15,23 @@ def priority_help_wanted(item):
     return 50
   return 0
 
-github(org="kubernetes-sigs", repo="kube-api-linter", filters=[authored_by_not_me], priorities=[priority_help_wanted])
+# Example of setting the status of an item based
+# on fields of the item.
+# In this case we want:
+# - IF item is an Issue AND does not have label triage/accepted THEN status = "Needs Triage"
+# - IF item is a PullRequest AND does not have any assignees AND is missing the LGTM label THEN status = "Needs Review"
+def set_status(item):
+  type = item.get("type")
+  labels = item.get("labels")
+  assignees = item.get("assignees")
+
+  if type == "Issue":
+    if "triage/accepted" not in labels:
+      return "Needs Triage"
+  if type == "PullRequest":
+    if len(assignees) == 0 and "lgtm" not in labels:
+      return "Needs Review"
+  return ""
+
+github(org="kubernetes-sigs", repo="kube-api-linter", filters=[authored_by_not_me], priorities=[priority_help_wanted], status=set_status)
 github(org="kubernetes-sigs", repo="crdify", filters=[authored_by_not_me])

--- a/pkg/builtins/github.go
+++ b/pkg/builtins/github.go
@@ -14,10 +14,11 @@ func githubBuiltinFunc(eng *engine.Engine) BuiltinFunc {
 	return func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var filters *starlark.List
 		var priorities *starlark.List
+		var status starlark.Callable
 		var org starlark.String
 		var repo starlark.String
 
-		err := starlark.UnpackArgs("github", args, kwargs, "org", &org, "repo", &repo, "filters?", &filters, "priorities?", &priorities)
+		err := starlark.UnpackArgs("github", args, kwargs, "org", &org, "repo", &repo, "filters?", &filters, "priorities?", &priorities, "status?", &status)
 		if err != nil {
 			return nil, err
 		}
@@ -32,7 +33,7 @@ func githubBuiltinFunc(eng *engine.Engine) BuiltinFunc {
 			priorityCallables = callablesFromList(priorities)
 		}
 
-		ghSource := github.New(org.GoString(), repo.GoString(), filterCallables, priorityCallables)
+		ghSource := github.New(org.GoString(), repo.GoString(), filterCallables, priorityCallables, status)
 		eng.AddSource(ghSource)
 
 		return starlark.None, nil

--- a/pkg/sources/github/types.go
+++ b/pkg/sources/github/types.go
@@ -20,4 +20,5 @@ type RepoItem struct {
 	Body      string       `json:"body"`
 	State     string       `json:"state"`
 	Priority  int          `json:"priority"`
+	Status    string       `json:"status"`
 }


### PR DESCRIPTION
Using the changes in this PR, users can now update the `status` of GitHub-sourced work items using a new `status` parameter in the `github()` builtin.

This allows for use of `synkr` in more robust pipelines where users may want to define distinct states of their work items separately from the platforms that they are sourced from. For example, setting the status of GitHub issue items to `Needs Triage` if the label `triage/accepted` is missing.